### PR TITLE
Implement Hashable for UUIDv4

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -1,0 +1,22 @@
+package:
+  dependencies:
+  - arrays
+  - assert
+  - console
+  - control
+  - effect
+  - foldable-traversable
+  - gen
+  - integers
+  - maybe
+  - partial
+  - prelude
+  - quickcheck
+  - random
+  - strings
+  - unordered-collections
+  name: uuidv4
+workspace:
+  extra_packages: {}
+  package_set:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.4-20221024/packages.json

--- a/src/UUID/Random.purs
+++ b/src/UUID/Random.purs
@@ -10,6 +10,7 @@ import Prelude
 
 import Control.Alternative (guard)
 import Data.Array as Array
+import Data.Hashable (class Hashable, hash)
 import Data.Int as Int
 import Data.Maybe (Maybe, fromJust)
 import Data.String as String
@@ -23,6 +24,9 @@ import Partial.Unsafe (unsafePartial)
 
 -- | A type for version 4 (random) UUIDs.
 data UUIDv4 = UUIDv4 String (Array Int)
+
+instance Hashable UUIDv4 where
+  hash (UUIDv4 s _) = hash s
 
 instance Eq UUIDv4 where
   eq (UUIDv4 a _) (UUIDv4 b _) = a == b


### PR DESCRIPTION
This PR adds `Hashable` typeclass implementation to the UUIDv4 type, together with adding necessary dependency (`unordered-collections`) to the `spago.yaml` descriptor.

I first tried to provide the typeclass instance just in my project where I wanted to use `UUIDv4` as keys in the HashMap datastructure, but as the `UUIDv4` type constructor is not exported (only the type is), I couldn't do it.